### PR TITLE
feat: 관리자 페이지 기본 구성

### DIFF
--- a/src/main/java/com/goorm/roomflow/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/goorm/roomflow/domain/admin/controller/AdminController.java
@@ -1,0 +1,17 @@
+package com.goorm.roomflow.domain.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    @GetMapping
+    public String adminPage() {
+        return "admin/admin";
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/room/controller/AdminMeetingRoomController.java
+++ b/src/main/java/com/goorm/roomflow/domain/room/controller/AdminMeetingRoomController.java
@@ -1,0 +1,29 @@
+package com.goorm.roomflow.domain.room.controller;
+
+import com.goorm.roomflow.domain.room.dto.response.MeetingRoomAdminRes;
+import com.goorm.roomflow.domain.room.service.MeetingRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/rooms")
+public class AdminMeetingRoomController {
+
+    private final MeetingRoomService meetingRoomService;
+
+    @GetMapping
+    public String roomList(Model model) {
+
+        List<MeetingRoomAdminRes> meetingRoomAdminListRes = meetingRoomService.readMeetingRoomAdminList();
+
+        model.addAttribute("rooms", meetingRoomAdminListRes);
+
+        return "admin/system/room-list";
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/room/dto/response/MeetingRoomAdminRes.java
+++ b/src/main/java/com/goorm/roomflow/domain/room/dto/response/MeetingRoomAdminRes.java
@@ -1,0 +1,17 @@
+package com.goorm.roomflow.domain.room.dto.response;
+
+import com.goorm.roomflow.domain.room.entity.RoomStatus;
+
+import java.math.BigDecimal;
+
+public record MeetingRoomAdminRes(
+        Long roomId,
+        String roomName,
+        int capacity,
+        String description,
+        BigDecimal hourlyPrice,
+        RoomStatus status,
+        String imageUrl,
+        int totalReservations
+) {
+}

--- a/src/main/java/com/goorm/roomflow/domain/room/service/MeetingRoomService.java
+++ b/src/main/java/com/goorm/roomflow/domain/room/service/MeetingRoomService.java
@@ -1,6 +1,7 @@
 package com.goorm.roomflow.domain.room.service;
 
 import com.goorm.roomflow.domain.room.dto.request.CreateRoomSlotsReq;
+import com.goorm.roomflow.domain.room.dto.response.MeetingRoomAdminRes;
 import com.goorm.roomflow.domain.room.dto.response.MeetingRoomListRes;
 
 import java.time.LocalDate;
@@ -10,4 +11,6 @@ public interface MeetingRoomService {
     MeetingRoomListRes getMeetingRoomsByDate(LocalDate date);
     void generateSlots(LocalDate targetDate);
     void generateSlotsForRoom(CreateRoomSlotsReq createRoomSlotsReq);
+
+    List<MeetingRoomAdminRes> readMeetingRoomAdminList();
 }

--- a/src/main/java/com/goorm/roomflow/domain/room/service/MeetingRoomServiceImpl.java
+++ b/src/main/java/com/goorm/roomflow/domain/room/service/MeetingRoomServiceImpl.java
@@ -4,9 +4,7 @@ import com.goorm.roomflow.domain.reservation.entity.ReservationPolicy;
 import com.goorm.roomflow.domain.reservation.repository.ReservationPolicyRepository;
 import com.goorm.roomflow.domain.room.dto.RoomSlotInsertDto;
 import com.goorm.roomflow.domain.room.dto.request.CreateRoomSlotsReq;
-import com.goorm.roomflow.domain.room.dto.response.MeetingRoomListRes;
-import com.goorm.roomflow.domain.room.dto.response.MeetingRoomRes;
-import com.goorm.roomflow.domain.room.dto.response.RoomSlotRes;
+import com.goorm.roomflow.domain.room.dto.response.*;
 import com.goorm.roomflow.domain.room.entity.MeetingRoom;
 import com.goorm.roomflow.domain.room.entity.RoomSlot;
 import com.goorm.roomflow.domain.room.entity.RoomStatus;
@@ -306,6 +304,32 @@ public class MeetingRoomServiceImpl implements MeetingRoomService {
             return 1;
         }
         return 2;
+    }
+
+    /**
+     * 관리자 기능 구현
+     */
+
+    /**
+     * 관리자 회의실 조회
+     */
+    @Override
+    public List<MeetingRoomAdminRes> readMeetingRoomAdminList() {
+
+        List<MeetingRoom> rooms = meetingRoomRepository.findAll();
+
+        return rooms.stream()
+                .map(room -> new MeetingRoomAdminRes(
+                        room.getRoomId(),
+                        room.getRoomName(),
+                        room.getCapacity(),
+                        room.getDescription(),
+                        room.getHourlyPrice(),
+                        room.getStatus(),
+                        room.getImageUrl(),
+                        room.getTotalReservations()
+                ))
+                .toList();
     }
 
 }

--- a/src/main/java/com/goorm/roomflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/roomflow/global/config/SecurityConfig.java
@@ -109,7 +109,7 @@ public class SecurityConfig {
 								"/css/**", "/js/**", "/images/**"
 						).permitAll()
 						.requestMatchers(HttpMethod.GET, "/rooms/**").permitAll()
-						.requestMatchers("/reservations/**", "/users/mypage/**").authenticated()
+						.requestMatchers("/reservations/**", "/users/mypage/**", "/admin/**").authenticated()
 						.anyRequest().authenticated()
 				)
 				.formLogin(form -> form

--- a/src/main/resources/templates/admin/admin.html
+++ b/src/main/resources/templates/admin/admin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/equip-list.css}">
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel='stylesheet' href='https://cdn-uicons.flaticon.com/4.0.0/uicons-regular-rounded/css/uicons-regular-rounded.css'>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+
+<div class="flex w-full">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('dashboard')}"></div>
+
+    <main class="flex-1 p-6">
+        내용 - 기본 구조
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/system/room-list.html
+++ b/src/main/resources/templates/admin/system/room-list.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회의실 관리 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+
+<div class="flex w-full">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('system')}"></div>
+
+    <main class="flex-1 p-6">
+        <div th:replace="~{admin/system/system-tabs :: systemTabs('rooms')}"></div>
+
+        <div class="flex items-center justify-end mb-6">
+            <a th:href="@{/admin/system/rooms/new}"
+               class="inline-flex items-center gap-2 px-4 py-2 bg-black text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition">
+                <i data-lucide="plus" class="w-4 h-4"></i>
+                회의실 등록
+            </a>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+            <div class="px-5 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">회의실 목록</h2>
+                <p class="text-sm text-gray-500 mt-1">
+                    총 <span th:text="${rooms != null ? #lists.size(rooms) : 0}"></span>개의 회의실이 있습니다.
+                </p>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                    <thead class="bg-gray-50 border-b border-gray-200">
+                    <tr>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">이미지</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">회의실명</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">설명</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">수용 인원</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">시간당 요금</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">상태</th>
+                        <th class="px-5 py-3 text-left font-medium text-gray-600">총 예약 수</th>
+                        <th class="px-5 py-3 text-right font-medium text-gray-600">관리</th>
+                    </tr>
+                    </thead>
+
+                    <tbody>
+                    <tr th:each="room : ${rooms}" class="border-b border-gray-100 last:border-b-0">
+                        <!-- 이미지 -->
+                        <td class="px-5 py-4">
+                            <div th:if="${room.imageUrl != null and !#strings.isEmpty(room.imageUrl)}"
+                                 class="w-14 h-14">
+                                <img th:src="${room.imageUrl}"
+                                     alt="회의실 이미지"
+                                     class="w-14 h-14 rounded-lg object-cover border border-gray-200">
+                            </div>
+                            <div th:if="${room.imageUrl == null or #strings.isEmpty(room.imageUrl)}"
+                                 class="w-14 h-14 rounded-lg border border-gray-200 bg-gray-100 flex items-center justify-center text-gray-400">
+                                <i data-lucide="image-off" class="w-5 h-5"></i>
+                            </div>
+                        </td>
+
+                        <!-- 회의실명 -->
+                        <td class="px-5 py-4 text-gray-900 font-medium" th:text="${room.roomName}"></td>
+
+                        <!-- 설명 -->
+                        <td class="px-5 py-4 text-gray-600" th:text="${room.description}"></td>
+
+                        <!-- 수용 인원 -->
+                        <td class="px-5 py-4 text-gray-700" th:text="${room.capacity} + '명'"></td>
+
+                        <!-- 시간당 요금 -->
+                        <td class="px-5 py-4 text-gray-700"
+                            th:text="${#numbers.formatInteger(room.hourlyPrice, 3, 'COMMA')} + '원'"></td>
+
+                        <!-- 상태 -->
+                        <td class="px-5 py-4">
+                            <span th:if="${room.status.name() == 'AVAILABLE'}"
+                                  class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700">
+                                예약 가능
+                            </span>
+
+                            <span th:if="${room.status.name() == 'MAINTENANCE'}"
+                                  class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-700">
+                                점검 중
+                            </span>
+
+                            <span th:if="${room.status.name() == 'INACTIVE'}"
+                                  class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-200 text-gray-700">
+                                비활성화
+                            </span>
+                        </td>
+
+                        <!-- 총 예약 수 -->
+                        <td class="px-5 py-4 text-gray-700" th:text="${room.totalReservations} + '건'"></td>
+
+                        <!-- 관리 -->
+                        <td class="px-5 py-4">
+                            <div class="flex items-center justify-end gap-2">
+                                <a th:href="@{|/admin/system/rooms/${room.roomId}|}"
+                                   class="px-3 py-2 border border-gray-300 rounded-lg text-xs hover:bg-gray-50 transition">
+                                    상세
+                                </a>
+
+                                <a th:href="@{|/admin/system/rooms/${room.roomId}/edit|}"
+                                   class="px-3 py-2 border border-gray-300 rounded-lg text-xs hover:bg-gray-50 transition">
+                                    수정
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr th:if="${rooms == null or #lists.isEmpty(rooms)}">
+                        <td colspan="8" class="px-5 py-12 text-center text-sm text-gray-400">
+                            등록된 회의실이 없습니다.
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+    lucide.createIcons();
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/system/system-tabs.html
+++ b/src/main/resources/templates/admin/system/system-tabs.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+<div th:fragment="systemTabs(activeTab)" class="mb-8">
+
+    <!-- 제목 영역 -->
+    <div class="mb-4">
+        <h1 class="text-2xl font-bold text-gray-900">
+            시스템 관리
+        </h1>
+
+        <p class="mt-1 text-sm text-gray-500">
+            회의실, 비품, 시간 슬롯, 공지사항, 정책 및 휴일을 관리합니다
+        </p>
+    </div>
+
+
+    <!-- 탭 영역 -->
+    <div class="w-full rounded-2xl bg-gray-100 p-1.5">
+        <nav class="grid grid-cols-6 gap-1.5">
+
+            <a th:href="@{/admin/system/rooms}"
+               th:classappend="${activeTab == 'rooms'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="calculator" class="w-4 h-4"></i>
+                회의실
+            </a>
+
+            <a th:href="@{/admin/system/equipments}"
+               th:classappend="${activeTab == 'equipments'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="package" class="w-4 h-4"></i>
+                비품
+            </a>
+
+            <a th:href="@{/admin/system/roomslots}"
+               th:classappend="${activeTab == 'roomslots'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="clock-3" class="w-4 h-4"></i>
+                시간 슬롯
+            </a>
+
+            <a th:href="@{/admin/system/notices}"
+               th:classappend="${activeTab == 'notices'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="bell" class="w-4 h-4"></i>
+                공지사항
+            </a>
+
+            <a th:href="@{/admin/system/policies}"
+               th:classappend="${activeTab == 'policies'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="shield-check" class="w-4 h-4"></i>
+                정책관리
+            </a>
+
+            <a th:href="@{/admin/system/holidays}"
+               th:classappend="${activeTab == 'holidays'} ? 'bg-white shadow-sm text-black' : 'text-gray-700 hover:bg-white/60'"
+               class="flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition">
+                <i data-lucide="calendar-days" class="w-4 h-4"></i>
+                휴일관리
+            </a>
+
+        </nav>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/admin-sidebar.html
+++ b/src/main/resources/templates/fragments/admin-sidebar.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+<aside th:fragment="adminSidebar(currentMenu)"
+       class="w-64 min-h-screen bg-white border-r border-gray-200 px-4 py-6">
+
+    <div class="mb-6 px-2">
+        <h2 class="text-lg font-semibold text-gray-900">관리자 메뉴</h2>
+        <p class="text-sm text-gray-500 mt-1">RoomFlow Admin</p>
+    </div>
+
+    <nav class="flex flex-col gap-2">
+
+        <a th:href="@{/admin}"
+           th:classappend="${currentMenu == 'dashboard'} ? 'bg-black text-white hover:bg-gray-800' : 'text-gray-700 hover:bg-gray-50'"
+           class="px-4 py-3 text-sm font-medium rounded-lg transition">
+            대시보드
+        </a>
+
+        <a th:href="@{/admin/users}"
+           th:classappend="${currentMenu == 'users'} ? 'bg-black text-white hover:bg-gray-800' : 'text-gray-700 hover:bg-gray-50'"
+           class="px-4 py-3 text-sm font-medium rounded-lg transition">
+            회원관리
+        </a>
+
+        <a th:href="@{/admin/rooms}"
+           th:classappend="${currentMenu == 'system'} ? 'bg-black text-white hover:bg-gray-800' : 'text-gray-700 hover:bg-gray-50'"
+           class="px-4 py-3 text-sm font-medium rounded-lg transition">
+            시스템관리
+        </a>
+
+        <a th:href="@{/admin/reservations}"
+           th:classappend="${currentMenu == 'reservations'} ? 'bg-black text-white hover:bg-gray-800' : 'text-gray-700 hover:bg-gray-50'"
+           class="px-4 py-3 text-sm font-medium rounded-lg transition">
+            예약관리
+        </a>
+
+        <a th:href="@{/admin/sales}"
+           th:classappend="${currentMenu == 'sales'} ? 'bg-black text-white hover:bg-gray-800' : 'text-gray-700 hover:bg-gray-50'"
+           class="px-4 py-3 text-sm font-medium rounded-lg transition">
+            매출관리
+        </a>
+
+    </nav>
+</aside>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -20,6 +20,12 @@
                    class="px-4 py-2 text-sm font-medium rounded-lg text-black hover:bg-gray-50">
                     회의실 조회
                 </a>
+
+                <!-- 관리자 페이지 추가 -->
+                <a th:href="@{/admin}"
+                   class="px-4 py-2 text-sm font-medium rounded-lg text-black hover:bg-gray-50">
+                    관리자 페이지
+                </a>
             </nav>
 
         </div>


### PR DESCRIPTION
## 📌 Related Issue
#85 close
## 🚀 Description
1. 관리자 기본 페이지 html와 controller 생성
2. 헤더에 관리자 페이지 생성
3. 관리자 관련 사이드바 생성
4. 회의실 목록 조회 임시 생성

## 📢 Notes
나중에 해야할 것
1. 관리자 페이지는 관리자만 보이게
2. 관리자 페이지들에 대해 접근 권한 제한