### PR TITLE
feat:  관리자 공지사항 관리, 사용자 공지사항 보기

### DIFF
--- a/src/main/java/com/goorm/roomflow/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/controller/AdminNoticeController.java
@@ -1,0 +1,177 @@
+package com.goorm.roomflow.domain.notice.controller;
+
+import com.goorm.roomflow.domain.notice.dto.request.NoticeReq;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminRes;
+import com.goorm.roomflow.domain.notice.service.NoticeAdminService;
+import com.goorm.roomflow.domain.user.service.CustomUser;
+import com.goorm.roomflow.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/notices")
+public class AdminNoticeController {
+
+    private final NoticeAdminService noticeAdminService;
+
+    /**
+     * 관리자 공지 목록 조회
+     */
+    @GetMapping
+    public String noticeList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Model model
+    ) {
+
+        Page<NoticeAdminRes> noticePage = noticeAdminService.readNoticeList(page - 1, size);
+
+        model.addAttribute("noticePage", noticePage);
+        model.addAttribute("notices", noticePage.getContent());
+        model.addAttribute("currentPage", page);
+        model.addAttribute("size", size);
+
+        return "admin/system/notice/notice-list.html";
+    }
+
+    /**
+     * 관리자 공지 상세 조회
+     */
+    @GetMapping("/{noticeId}")
+    public String noticeDetail(
+            @PathVariable Long noticeId,
+            Model model
+    ) {
+
+        NoticeAdminDetailRes notice = noticeAdminService.readNoticeDetail(noticeId);
+        model.addAttribute("notice", notice);
+
+        return "admin/system/notice/notice-detail";
+    }
+
+    /**
+     * 관리자 공지 생성 페이지
+     */
+    @GetMapping("/create")
+    public String createNoticePage(Model model) {
+        if (!model.containsAttribute("createForm")) {
+            model.addAttribute("createForm", new NoticeReq("", "", false, true));
+        }
+
+        return "admin/system/notice/notice-create";
+    }
+
+    /**
+     * 공지 생성
+     */
+    @PostMapping("/create")
+    public String createNotice(
+            @AuthenticationPrincipal CustomUser currentUser,
+            @ModelAttribute("createForm") NoticeReq request,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            noticeAdminService.createNotice(currentUser.getUserId(), request);
+
+            redirectAttributes.addFlashAttribute("message", "공지사항이 등록되었습니다.");
+            redirectAttributes.addFlashAttribute("alertType", "success");
+
+            return "redirect:/admin/notices";
+
+        } catch (BusinessException | IllegalArgumentException e) {
+            model.addAttribute("createErrorMessage", e.getMessage());
+            return "admin/system/notice/notice-create";
+        }
+    }
+
+    /**
+     * 관리자 공지 수정 페이지
+     */
+    @GetMapping("/{noticeId}/edit")
+    public String modifyNoticePage(
+            @PathVariable Long noticeId,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            NoticeAdminDetailRes notice = noticeAdminService.readNoticeDetail(noticeId);
+            model.addAttribute("notice", notice);
+
+            if (!model.containsAttribute("modifyForm")) {
+                model.addAttribute("modifyForm", new NoticeReq(
+                        notice.title(),
+                        notice.content(),
+                        notice.pinned(),
+                        notice.visible()
+                ));
+            }
+
+            return "admin/system/notice/notice-edit";
+
+        } catch (BusinessException | IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            redirectAttributes.addFlashAttribute("alertType", "error");
+            return "redirect:/admin/notices";
+        }
+    }
+
+    /**
+     * 공지 수정
+     */
+    @PostMapping("/{noticeId}/edit")
+    public String modifyNotice(
+            @AuthenticationPrincipal CustomUser currentUser,
+            @PathVariable Long noticeId,
+            @ModelAttribute("modifyForm") NoticeReq request,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+
+        try {
+            noticeAdminService.modifyNotice(currentUser.getUserId(), noticeId, request);
+
+            redirectAttributes.addFlashAttribute("message", "공지사항이 수정되었습니다.");
+            redirectAttributes.addFlashAttribute("alertType", "success");
+
+            return "redirect:/admin/notices/" + noticeId;
+
+        } catch (BusinessException | IllegalArgumentException e) {
+            NoticeAdminDetailRes notice = noticeAdminService.readNoticeDetail(noticeId);
+            model.addAttribute("notice", notice);
+            model.addAttribute("modifyErrorMessage", e.getMessage());
+
+            return "admin/system/notice/notice-edit";
+        }
+    }
+
+    /**
+     * 공지 삭제
+     */
+    @PostMapping("/{noticeId}/delete")
+    public String deleteNotice(
+            @PathVariable Long noticeId,
+            RedirectAttributes redirectAttributes
+    ) {
+
+        try {
+            noticeAdminService.deleteNotice(noticeId);
+
+            redirectAttributes.addFlashAttribute("message", "공지사항이 삭제되었습니다.");
+            redirectAttributes.addFlashAttribute("alertType", "success");
+
+        } catch (BusinessException | IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            redirectAttributes.addFlashAttribute("alertType", "error");
+        }
+
+        return "redirect:/admin/notices";
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/controller/NoticeController.java
@@ -1,0 +1,48 @@
+package com.goorm.roomflow.domain.notice.controller;
+
+import com.goorm.roomflow.domain.notice.dto.response.NoticeDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeRes;
+import com.goorm.roomflow.domain.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/notices")
+public class NoticeController {
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public String noticeList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Model model
+    ) {
+        Page<NoticeRes> noticePage = noticeService.readNoticeList(page - 1, size);
+
+        model.addAttribute("noticePage", noticePage);
+        model.addAttribute("notices", noticePage.getContent());
+        model.addAttribute("currentPage", page);
+        model.addAttribute("size", size);
+
+        return "notice/notice-list.html";
+    }
+
+    @GetMapping("/{noticeId}")
+    public String noticeDetail(
+            @PathVariable Long noticeId,
+            Model model
+    ) {
+
+        NoticeDetailRes notice = noticeService.readNotice(noticeId);
+        model.addAttribute("notice", notice);
+
+        return "notice/notice-detail";
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/dto/request/NoticeReq.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/dto/request/NoticeReq.java
@@ -1,0 +1,9 @@
+package com.goorm.roomflow.domain.notice.dto.request;
+
+public record NoticeReq(
+        String title,
+        String content,
+        boolean pinned,
+        boolean visible
+) {
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeAdminDetailRes.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeAdminDetailRes.java
@@ -1,0 +1,18 @@
+package com.goorm.roomflow.domain.notice.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeAdminDetailRes(
+
+        Long noticeId,
+        String title,
+        String content,
+        boolean pinned,
+        boolean visible,
+        int viewCount,
+        String createdByName,
+        LocalDateTime createdAt,
+        String updatedByName,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeAdminRes.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeAdminRes.java
@@ -1,0 +1,13 @@
+package com.goorm.roomflow.domain.notice.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeAdminRes(
+        Long noticeId,
+        String title,
+        boolean pinned,
+        boolean visible,
+        int viewCount,
+        LocalDateTime createdAt,
+         LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeDetailRes.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeDetailRes.java
@@ -1,0 +1,14 @@
+package com.goorm.roomflow.domain.notice.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeDetailRes(
+        Long noticeId,
+        String title,
+        String content,
+        boolean pinned,
+        int viewCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeRes.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/dto/response/NoticeRes.java
@@ -1,0 +1,12 @@
+package com.goorm.roomflow.domain.notice.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeRes(
+        Long noticeId,
+        String title,
+        boolean pinned,
+        int viewCount,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/entity/Notice.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/entity/Notice.java
@@ -1,0 +1,76 @@
+package com.goorm.roomflow.domain.notice.entity;
+
+import com.goorm.roomflow.domain.BaseEntity;
+import com.goorm.roomflow.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "notices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long noticeId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_pinned", nullable = false)
+    private boolean pinned = false;
+
+    @Column(name = "is_visibled", nullable = false)
+    private boolean visible = true;
+
+    @Column(nullable = false)
+    private int viewCount = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "updated_by")
+    private User updatedBy;
+
+    @Builder
+    public Notice(String title, String content, boolean pinned, boolean visible, User createdBy) {
+        validateNotice(title, content);
+
+        this.title = title;
+        this.content = content;
+        this.pinned = pinned;
+        this.visible = visible;
+        this.createdBy = createdBy;
+        this.updatedBy = createdBy;
+    }
+
+    public void modify(String title, String content, boolean pinned, boolean visible, User updatedBy) {
+        validateNotice(title, content);
+
+        this.title = title;
+        this.content = content;
+        this.pinned = pinned;
+        this.visible = visible;
+        this.updatedBy = updatedBy;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    private void validateNotice(String title, String content) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("공지 제목은 비어 있을 수 없습니다.");
+        }
+
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("공지 내용은 비어 있을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/mapper/NoticeMapper.java
@@ -1,0 +1,26 @@
+package com.goorm.roomflow.domain.notice.mapper;
+
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeRes;
+import com.goorm.roomflow.domain.notice.entity.Notice;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NoticeMapper {
+
+    NoticeAdminRes toNoticeAdminRes(Notice notice);
+
+    @Mapping(target = "createdByName", expression = "java(getUserName(notice.getCreatedBy()))")
+    @Mapping(target = "updatedByName", expression = "java(getUserName(notice.getUpdatedBy()))")
+    NoticeAdminDetailRes toNoticeAdminDetailRes(Notice notice);
+
+    NoticeRes toNoticeRes(Notice notice);
+    NoticeDetailRes toNoticeDetailRes(Notice notice);
+
+    default String getUserName(com.goorm.roomflow.domain.user.entity.User user) {
+        return user != null ? user.getName() : null;
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,23 @@
+package com.goorm.roomflow.domain.notice.repository;
+
+import com.goorm.roomflow.domain.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    Page<Notice> findByVisibleTrue(Pageable pageable);
+    Optional<Notice> findByNoticeIdAndVisibleTrue(Long noticeId);
+
+    @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
+    Page<Notice> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
+    Optional<Notice> findByNoticeId(Long noticeId);
+
+    Optional<Notice> findFirstByVisibleTrueOrderByPinnedDescCreatedAtDesc();
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeAdminService.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeAdminService.java
@@ -1,0 +1,16 @@
+package com.goorm.roomflow.domain.notice.service;
+
+import com.goorm.roomflow.domain.notice.dto.request.NoticeReq;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminRes;
+import org.springframework.data.domain.Page;
+
+public interface NoticeAdminService {
+
+    Page<NoticeAdminRes> readNoticeList(int page, int size);
+    NoticeAdminDetailRes readNoticeDetail(Long noticeId);
+
+    void createNotice(Long userId, NoticeReq noticeReq);
+    void modifyNotice(Long userId, Long noticeId, NoticeReq noticeReq);
+    void deleteNotice(Long noticeId);
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeAdminServiceImpl.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeAdminServiceImpl.java
@@ -1,0 +1,134 @@
+package com.goorm.roomflow.domain.notice.service;
+
+import com.goorm.roomflow.domain.notice.dto.request.NoticeReq;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeAdminRes;
+import com.goorm.roomflow.domain.notice.entity.Notice;
+import com.goorm.roomflow.domain.notice.mapper.NoticeMapper;
+import com.goorm.roomflow.domain.notice.repository.NoticeRepository;
+import com.goorm.roomflow.domain.user.entity.User;
+import com.goorm.roomflow.domain.user.repository.UserJpaRepository;
+import com.goorm.roomflow.global.code.ErrorCode;
+import com.goorm.roomflow.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeAdminServiceImpl implements NoticeAdminService {
+
+    private final NoticeRepository noticeRepository;
+    private final UserJpaRepository userRepository;
+
+    private final NoticeMapper noticeMapper;
+
+    /**
+     * 관리자 공지 목록 조회
+     */
+    @Override
+    public Page<NoticeAdminRes> readNoticeList(int page, int size) {
+
+        log.info("[공지사항-관리자] 목록 조회 시작 - page={}, size={}", page, size);
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(
+                        Sort.Order.desc("pinned"),
+                        Sort.Order.desc("createdAt")
+                )
+        );
+
+        Page<NoticeAdminRes> noticeAdminList = noticeRepository.findAll(pageable)
+                .map(noticeMapper::toNoticeAdminRes);
+
+        log.info("[공지사항-관리자] 목록 조회 완료 - totalElements={}", noticeAdminList.getTotalElements());
+
+        return noticeAdminList;
+    }
+
+    /**
+     * 관리자 공지 상세 조회
+     */
+
+    @Override
+    public NoticeAdminDetailRes readNoticeDetail(Long noticeId) {
+
+        log.info("[공지사항-관리자] 상세 조회 시작 - noticeId={}", noticeId);
+        Notice notice = loadNotice(noticeId);
+
+        log.info("[공지사항-관리자] 상세 조회 완료 - noticeId={}", noticeId);
+
+        return noticeMapper.toNoticeAdminDetailRes(notice);
+    }
+
+    /**
+     * 관리자 공지 사항 생성
+     */
+    @Override
+    @Transactional
+    public void createNotice(Long userId, NoticeReq noticeReq) {
+        log.info("[공지사항-관리자] 공지 생성 시작 - userId={}, title={}", userId, noticeReq.title());
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Notice notice = Notice.builder()
+                .title(noticeReq.title())
+                .content(noticeReq.content())
+                .pinned(noticeReq.pinned())
+                .visible(noticeReq.visible())
+                .createdBy(user)
+                .build();
+
+        noticeRepository.save(notice);
+
+        log.info("[공지사항-관리자] 공지 생성 완료 - noticeId={}", notice.getNoticeId());
+    }
+
+    /**
+     * 관리자 공지 사항 수정
+     */
+    @Override
+    @Transactional
+    public void modifyNotice(Long userId, Long noticeId, NoticeReq noticeReq) {
+        log.info("[공지사항-관리자] 공지 수정 시작 - userId={}, noticeId={}", userId, noticeId);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Notice notice = loadNotice(noticeId);
+        notice.modify(noticeReq.title(), noticeReq.content(), noticeReq.pinned(), noticeReq.visible(), user);
+
+        log.info("[공지사항-관리자] 공지 수정 완료 - noticeId={}", notice.getNoticeId());
+    }
+
+    /**
+     * 관리자 공지 사항 삭제
+     */
+    @Override
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        log.info("[공지사항-관리자] 공지 삭제 시작 - noticeId={}", noticeId);
+
+        Notice notice = loadNotice(noticeId);
+        noticeRepository.delete(notice);
+
+        log.info("[공지사항-관리자] 공지 삭제 완료 - noticeId={}", noticeId);
+    }
+
+    private Notice loadNotice(Long noticeId) {
+        Notice notice = noticeRepository.findByNoticeId(noticeId).orElseThrow(() -> {
+            log.warn("[공지사항-관리자] 공지 삭제 실패 - 공지 없음 noticeId={}", noticeId);
+            return new BusinessException(ErrorCode.NOTICE_NOT_FOUND);
+        });
+
+        return notice;
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeService.java
@@ -1,0 +1,12 @@
+package com.goorm.roomflow.domain.notice.service;
+
+import com.goorm.roomflow.domain.notice.dto.response.NoticeDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeRes;
+import org.springframework.data.domain.Page;
+
+public interface NoticeService {
+
+    Page<NoticeRes> readNoticeList(int page, int size);
+    NoticeDetailRes readNotice(Long noticeId);
+    NoticeRes findPreviewNotice();
+}

--- a/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/com/goorm/roomflow/domain/notice/service/NoticeServiceImpl.java
@@ -1,0 +1,77 @@
+package com.goorm.roomflow.domain.notice.service;
+
+import com.goorm.roomflow.domain.notice.dto.response.NoticeDetailRes;
+import com.goorm.roomflow.domain.notice.dto.response.NoticeRes;
+import com.goorm.roomflow.domain.notice.entity.Notice;
+import com.goorm.roomflow.domain.notice.mapper.NoticeMapper;
+import com.goorm.roomflow.domain.notice.repository.NoticeRepository;
+import com.goorm.roomflow.global.code.ErrorCode;
+import com.goorm.roomflow.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeMapper noticeMapper;
+
+    /**
+     * 사용자 공지 목록 조회
+     */
+    @Override
+    public Page<NoticeRes> readNoticeList(int page, int size) {
+        log.info("[공지사항-사용자] 목록 조회 시작 - page: {}, size: {}", page, size);
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(
+                        Sort.Order.desc("pinned"),
+                        Sort.Order.desc("createdAt")
+                )
+        );
+
+        Page<NoticeRes> noticeList = noticeRepository.findByVisibleTrue(pageable).map(noticeMapper::toNoticeRes);
+
+        log.info("[공지사항-사용자] 목록 조회 완료 - totalElements: {}", noticeList.getTotalElements());
+
+        return noticeList;
+    }
+
+    /**
+     * 사용자 공지 상세 조회
+     */
+    @Override
+    @Transactional
+    public NoticeDetailRes readNotice(Long noticeId) {
+        log.info("[공지사항-사용자] 상세 조회 시작 -  noticeId={}", noticeId);
+
+        Notice notice = noticeRepository.findByNoticeIdAndVisibleTrue(noticeId)
+                .orElseThrow(() -> {
+                    log.warn("[공지사항-사용자] 상세 조회 실패 - 공지 없음 noticeId={}", noticeId);
+                    return new BusinessException(ErrorCode.NOTICE_NOT_FOUND);
+                });
+
+        notice.increaseViewCount();
+
+        log.info("[공지사항-사용자] 상세 조회 완료 -  noticeId={}", noticeId);
+        return noticeMapper.toNoticeDetailRes(notice);
+    }
+
+    @Override
+    public NoticeRes findPreviewNotice() {
+        return noticeRepository.findFirstByVisibleTrueOrderByPinnedDescCreatedAtDesc()
+                .map(noticeMapper::toNoticeRes)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/goorm/roomflow/domain/room/controller/MeetingRoomController.java
+++ b/src/main/java/com/goorm/roomflow/domain/room/controller/MeetingRoomController.java
@@ -1,5 +1,6 @@
 package com.goorm.roomflow.domain.room.controller;
 
+import com.goorm.roomflow.domain.notice.service.NoticeService;
 import com.goorm.roomflow.domain.room.dto.response.MeetingRoomListRes;
 import com.goorm.roomflow.domain.room.service.MeetingRoomService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 public class MeetingRoomController {
 
     private final MeetingRoomService meetingRoomService;
+    private final NoticeService noticeService;
 
     @GetMapping
     public String rooms(
@@ -33,6 +35,7 @@ public class MeetingRoomController {
 
         model.addAttribute("meetingRoomList", meetingRoomListRes);
         model.addAttribute("selectedDate", selectedDate);
+        model.addAttribute("notice", noticeService.findPreviewNotice());
 
         return "meeting-room/list";
     }

--- a/src/main/java/com/goorm/roomflow/global/code/ErrorCode.java
+++ b/src/main/java/com/goorm/roomflow/global/code/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode {
 	SOCIAL_REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "OAUTH_003","소셜 refresh token이 존재하지 않습니다."),
 	SOCIAL_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "OAUTH_004", "소셜 계정 연동 해제에 실패했습니다."),
 
+	//공지사항 에러
+	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_001", "공지사항을 찾을 수 없습니다."),
+
 	// 회의실
 	ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_001", "회의실을 찾을 수 없습니다."),
 	ROOM_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "ROOM_002", "예약이 가능한 회의실이 아닙니다."),

--- a/src/main/java/com/goorm/roomflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/roomflow/global/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 								"/swagger-ui/**", "/v3/api-docs/**",
 								"/css/**", "/js/**", "/images/**", "/reservations/**", "/api/v1/**"
 						).permitAll()
-						.requestMatchers(HttpMethod.GET, "/rooms/**").permitAll()
+						.requestMatchers(HttpMethod.GET, "/rooms/**", "/notices/**").permitAll()
 						.requestMatchers("/users/mypage/**", "/users/reservationlist", "/admin/**").authenticated()
 						.anyRequest().authenticated()
 				)

--- a/src/main/resources/templates/admin/system/notice/notice-create.html
+++ b/src/main/resources/templates/admin/system/notice/notice-create.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공지사항 등록 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+<th:block th:replace="~{fragments/alert-script :: alertScript}"></th:block>
+
+<div class="flex w-full min-h-screen">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('system')}"></div>
+
+    <main class="flex-1 p-6">
+        <div th:replace="~{admin/system/system-tabs :: systemTabs('notices')}"></div>
+
+        <div class="mb-6">
+            <h1 class="text-2xl font-bold text-gray-900 mt-2">공지사항 등록</h1>
+            <p class="text-sm text-gray-500 mt-1">사용자에게 전달할 공지사항을 등록합니다.</p>
+        </div>
+
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 max-w-5xl">
+            <form th:action="@{/admin/notices/create}"
+                  method="post"
+                  th:object="${createForm}"
+                  class="space-y-6">
+
+                <input type="hidden"
+                       th:name="${_csrf.parameterName}"
+                       th:value="${_csrf.token}">
+
+                <div th:if="${createErrorMessage != null}"
+                     class="px-4 py-3 rounded-lg bg-red-50 text-red-600 text-sm"
+                     th:text="${createErrorMessage}">
+                </div>
+
+                <div>
+                    <label for="title" class="block text-sm font-medium text-gray-700 mb-2">제목</label>
+                    <input type="text"
+                           id="title"
+                           th:field="*{title}"
+                           class="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                           placeholder="공지 제목을 입력해주세요.">
+                    <p th:if="${#fields.hasErrors('title')}"
+                       th:errors="*{title}"
+                       class="mt-2 text-sm text-red-500"></p>
+                </div>
+
+                <div>
+                    <label for="content" class="block text-sm font-medium text-gray-700 mb-2">내용</label>
+                    <textarea id="content"
+                              th:field="*{content}"
+                              rows="16"
+                              class="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm leading-6 resize-y min-h-[340px] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                              placeholder="공지 내용을 입력해주세요. 줄바꿈은 그대로 반영됩니다."></textarea>
+                    <p th:if="${#fields.hasErrors('content')}"
+                       th:errors="*{content}"
+                       class="mt-2 text-sm text-red-500"></p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <label class="flex items-start gap-3 p-4 rounded-xl border border-gray-200 bg-gray-50 cursor-pointer hover:border-blue-200 hover:bg-blue-50/30">
+                        <input type="checkbox" th:field="*{pinned}" class="h-4 w-4 mt-0.5">
+                        <div>
+                            <p class="text-sm font-medium text-gray-800">상단 고정</p>
+                            <p class="text-xs text-gray-500 mt-1">목록 상단에 우선 노출됩니다.</p>
+                        </div>
+                    </label>
+
+                    <label class="flex items-start gap-3 p-4 rounded-xl border border-gray-200 bg-gray-50 cursor-pointer hover:border-blue-200 hover:bg-blue-50/30">
+                        <input type="checkbox" th:field="*{visible}" class="h-4 w-4 mt-0.5">
+                        <div>
+                            <p class="text-sm font-medium text-gray-800">사용자 노출</p>
+                            <p class="text-xs text-gray-500 mt-1">사용자 공지 목록에 공개됩니다.</p>
+                        </div>
+                    </label>
+                </div>
+
+                <div class="flex items-center justify-between pt-2">
+                    <a th:href="@{/admin/notices}"
+                       class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        목록으로
+                    </a>
+
+                    <div class="flex items-center gap-3">
+                        <a th:href="@{/admin/notices}"
+                           class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            취소
+                        </a>
+                        <button type="submit"
+                                class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                            등록
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/system/notice/notice-detail.html
+++ b/src/main/resources/templates/admin/system/notice/notice-detail.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공지사항 상세 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+<th:block th:replace="~{fragments/alert-script :: alertScript}"></th:block>
+
+<div class="flex w-full min-h-screen">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('system')}"></div>
+
+    <main class="flex-1 p-6">
+        <div th:replace="~{admin/system/system-tabs :: systemTabs('notices')}"></div>
+
+        <div class="mb-6">
+            <h1 class="text-2xl font-bold text-gray-900 mt-2">공지사항 상세</h1>
+            <p class="text-sm text-gray-500 mt-1">공지사항에 대한 자세한 정보를 확인합니다.</p>
+        </div>
+
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+            <div class="px-8 py-7 border-b border-gray-100">
+                <div class="flex flex-wrap items-center gap-2 mb-4">
+                    <span th:if="${notice.pinned}"
+                          class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-700">
+                        고정 공지
+                    </span>
+
+                    <span th:if="${notice.visible}"
+                          class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">
+                        노출 중
+                    </span>
+
+                    <span th:unless="${notice.visible}"
+                          class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-500">
+                        숨김
+                    </span>
+                </div>
+
+                <h2 class="text-2xl font-bold text-gray-900 break-words"
+                    th:text="${notice.title}">
+                    공지 제목
+                </h2>
+
+                <!-- 조회수는 제목 아래 메타 정보처럼 분리 -->
+                <div class="flex items-center gap-2 mt-4 text-sm text-gray-500">
+                    <i data-lucide="eye" class="w-4 h-4"></i>
+                    <span>조회수</span>
+                    <span class="font-semibold text-gray-800" th:text="${notice.viewCount}">0</span>
+                </div>
+
+                <!-- 등록/수정 정보만 카드 형태 유지 -->
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+                    <div class="rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+                        <p class="text-xs font-semibold text-gray-500">등록 정보</p>
+                        <div class="mt-2 space-y-1 text-sm text-gray-700">
+                            <p>
+                                <span class="font-medium text-gray-900">등록자</span>
+                                <span class="ml-2" th:text="${notice.createdByName}">관리자</span>
+                            </p>
+                            <p>
+                                <span class="font-medium text-gray-900">등록일</span>
+                                <span class="ml-2"
+                                      th:text="${#temporals.format(notice.createdAt, 'yyyy-MM-dd HH:mm')}">2026-04-07 10:00</span>
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+                        <p class="text-xs font-semibold text-gray-500">최종 수정 정보</p>
+                        <div class="mt-2 space-y-1 text-sm text-gray-700">
+                            <p>
+                                <span class="font-medium text-gray-900">수정자</span>
+                                <span class="ml-2" th:text="${notice.updatedByName}">관리자</span>
+                            </p>
+                            <p>
+                                <span class="font-medium text-gray-900">수정일</span>
+                                <span class="ml-2"
+                                      th:text="${#temporals.format(notice.updatedAt, 'yyyy-MM-dd HH:mm')}">2026-04-07 10:00</span>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="px-8 py-10">
+                <div class="max-w-none whitespace-pre-line break-words text-[15px] text-gray-800 leading-8"
+                     th:text="${notice.content}">
+                    공지 내용
+                </div>
+            </div>
+
+            <div class="px-8 py-5 border-t border-gray-100 flex items-center justify-between">
+                <a th:href="@{/admin/notices}"
+                   class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+                    목록으로
+                </a>
+
+                <div class="flex items-center gap-3">
+                    <a th:href="@{/admin/notices/{noticeId}/edit(noticeId=${notice.noticeId})}"
+                       class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                        수정
+                    </a>
+
+                    <form id="deleteNoticeForm"
+                          th:action="@{/admin/notices/{noticeId}/delete(noticeId=${notice.noticeId})}"
+                          method="post">
+                        <input type="hidden"
+                               th:name="${_csrf.parameterName}"
+                               th:value="${_csrf.token}">
+                        <button type="button"
+                                id="deleteNoticeButton"
+                                class="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700">
+                            삭제
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        lucide.createIcons();
+
+        const deleteButton = document.getElementById("deleteNoticeButton");
+        const deleteForm = document.getElementById("deleteNoticeForm");
+
+        if (deleteButton && deleteForm) {
+            deleteButton.addEventListener("click", () => {
+                Swal.fire({
+                    title: "공지사항을 삭제하시겠습니까?",
+                    text: "삭제 후에는 되돌릴 수 없습니다.",
+                    icon: "warning",
+                    showCancelButton: true,
+                    confirmButtonText: "삭제",
+                    cancelButtonText: "취소",
+                    reverseButtons: true,
+                    confirmButtonColor: "#dc2626",
+                    cancelButtonColor: "#9ca3af"
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        deleteForm.submit();
+                    }
+                });
+            });
+        }
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/system/notice/notice-edit.html
+++ b/src/main/resources/templates/admin/system/notice/notice-edit.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공지사항 수정 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+<th:block th:replace="~{fragments/alert-script :: alertScript}"></th:block>
+
+<div class="flex w-full min-h-screen">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('system')}"></div>
+
+    <main class="flex-1 p-6">
+        <div th:replace="~{admin/system/system-tabs :: systemTabs('notices')}"></div>
+
+        <div class="mb-6">
+            <h1 class="text-2xl font-bold text-gray-900 mt-2">공지사항 수정</h1>
+            <p class="text-sm text-gray-500 mt-1">공지 내용을 수정하고 노출 상태를 변경할 수 있습니다.</p>
+        </div>
+
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 max-w-5xl">
+            <form th:action="@{/admin/notices/{noticeId}/edit(noticeId=${notice.noticeId})}"
+                  method="post"
+                  th:object="${modifyForm}"
+                  class="space-y-6">
+
+                <input type="hidden"
+                       th:name="${_csrf.parameterName}"
+                       th:value="${_csrf.token}">
+
+                <div th:if="${modifyErrorMessage != null}"
+                     class="px-4 py-3 rounded-lg bg-red-50 text-red-600 text-sm"
+                     th:text="${modifyErrorMessage}">
+                </div>
+
+                <div>
+                    <label for="title" class="block text-sm font-medium text-gray-700 mb-2">제목</label>
+                    <input type="text"
+                           id="title"
+                           th:field="*{title}"
+                           class="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                           placeholder="공지 제목을 입력해주세요.">
+                    <p th:if="${#fields.hasErrors('title')}"
+                       th:errors="*{title}"
+                       class="mt-2 text-sm text-red-500"></p>
+                </div>
+
+                <div>
+                    <label for="content" class="block text-sm font-medium text-gray-700 mb-2">내용</label>
+                    <textarea id="content"
+                              th:field="*{content}"
+                              rows="16"
+                              class="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm leading-6 resize-y min-h-[340px] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                              placeholder="공지 내용을 입력해주세요. 줄바꿈은 그대로 반영됩니다."></textarea>
+                    <p th:if="${#fields.hasErrors('content')}"
+                       th:errors="*{content}"
+                       class="mt-2 text-sm text-red-500"></p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <label class="flex items-start gap-3 p-4 rounded-xl border border-gray-200 bg-gray-50 cursor-pointer hover:border-blue-200 hover:bg-blue-50/30">
+                        <input type="checkbox" th:field="*{pinned}" class="h-4 w-4 mt-0.5">
+                        <div>
+                            <p class="text-sm font-medium text-gray-800">상단 고정</p>
+                            <p class="text-xs text-gray-500 mt-1">목록 상단에 우선 노출됩니다.</p>
+                        </div>
+                    </label>
+
+                    <label class="flex items-start gap-3 p-4 rounded-xl border border-gray-200 bg-gray-50 cursor-pointer hover:border-blue-200 hover:bg-blue-50/30">
+                        <input type="checkbox" th:field="*{visible}" class="h-4 w-4 mt-0.5">
+                        <div>
+                            <p class="text-sm font-medium text-gray-800">사용자 노출</p>
+                            <p class="text-xs text-gray-500 mt-1">사용자 공지 목록에 공개됩니다.</p>
+                        </div>
+                    </label>
+                </div>
+
+                <div class="flex items-center justify-between pt-2">
+                    <a th:href="@{/admin/notices}"
+                       class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        목록으로
+                    </a>
+
+                    <div class="flex items-center gap-3">
+                        <a th:href="@{/admin/notices/{noticeId}(noticeId=${notice.noticeId})}"
+                           class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            취소
+                        </a>
+                        <button type="submit"
+                                class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                            수정
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/system/notice/notice-list.html
+++ b/src/main/resources/templates/admin/system/notice/notice-list.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공지사항 관리 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body class="bg-gray-50">
+<div th:replace="~{fragments/header :: header}"></div>
+<th:block th:replace="~{fragments/alert-script :: alertScript}"></th:block>
+
+<div class="flex w-full min-h-screen">
+    <div th:replace="~{fragments/admin-sidebar :: adminSidebar('system')}"></div>
+
+    <main class="flex-1 p-6">
+        <div th:replace="~{admin/system/system-tabs :: systemTabs('notices')}"></div>
+
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+                <h1 class="text-2xl font-bold text-gray-900">공지사항 관리</h1>
+                <p class="text-sm text-gray-500 mt-1">공지사항을 등록하고 사용자 노출 여부를 관리할 수 있습니다.</p>
+            </div>
+
+            <a th:href="@{/admin/notices/create}"
+               class="inline-flex items-center justify-center px-4 py-2.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                공지 등록
+            </a>
+        </div>
+
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                    <thead class="bg-gray-50 border-b border-gray-200 text-gray-600">
+                    <tr>
+                        <th class="px-6 py-4 text-left font-semibold w-20">번호</th>
+                        <th class="px-6 py-4 text-left font-semibold min-w-[320px]">제목</th>
+                        <th class="px-6 py-4 text-center font-semibold w-24">고정</th>
+                        <th class="px-6 py-4 text-center font-semibold w-24">노출</th>
+                        <th class="px-6 py-4 text-center font-semibold w-24">조회수</th>
+                        <th class="px-6 py-4 text-center font-semibold w-44">등록일</th>
+                        <th class="px-6 py-4 text-center font-semibold w-44">수정일</th>
+                        <th class="px-6 py-4 text-center font-semibold w-36">관리</th>
+                    </tr>
+                    </thead>
+
+                    <tbody class="divide-y divide-gray-100">
+                    <tr th:if="${#lists.isEmpty(notices)}">
+                        <td colspan="8" class="px-6 py-20">
+                            <div class="flex flex-col items-center justify-center text-center">
+                                <div class="w-14 h-14 rounded-full bg-gray-100 flex items-center justify-center text-gray-400 text-xl mb-4">
+                                    !
+                                </div>
+                                <p class="text-base font-semibold text-gray-700">등록된 공지사항이 없습니다.</p>
+                                <p class="text-sm text-gray-400 mt-1">첫 공지사항을 등록해보세요.</p>
+                                <a th:href="@{/admin/notices/create}"
+                                   class="mt-5 inline-flex items-center px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                                    공지 등록
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr th:each="notice : ${notices}" class="hover:bg-gray-50">
+                        <td class="px-6 py-5 text-gray-700 align-top" th:text="${notice.noticeId}">1</td>
+
+                        <td class="px-6 py-5 align-top">
+                            <a th:href="@{/admin/notices/{noticeId}(noticeId=${notice.noticeId})}"
+                               class="block group">
+                                <div class="flex items-start gap-2">
+                                    <div class="min-w-0">
+                                        <p class="font-semibold text-gray-900 group-hover:text-blue-600 break-all"
+                                           th:text="${notice.title}">
+                                            공지 제목
+                                        </p>
+                                        <p class="text-xs text-gray-400 mt-1">
+                                            상세 보기
+                                        </p>
+                                    </div>
+                                </div>
+                            </a>
+                        </td>
+
+                        <td class="px-6 py-5 text-center align-top">
+                            <span th:if="${notice.pinned}"
+                                  class="inline-flex min-w-[52px] justify-center px-2.5 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-700">
+                                고정
+                            </span>
+                            <span th:unless="${notice.pinned}" class="text-gray-400">-</span>
+                        </td>
+
+                        <td class="px-6 py-5 text-center align-top">
+                            <span th:if="${notice.visible}"
+                                  class="inline-flex min-w-[52px] justify-center px-2.5 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">
+                                노출
+                            </span>
+                            <span th:unless="${notice.visible}"
+                                  class="inline-flex min-w-[52px] justify-center px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-500">
+                                숨김
+                            </span>
+                        </td>
+
+                        <td class="px-6 py-5 text-center text-gray-700 align-top" th:text="${notice.viewCount}">0</td>
+
+                        <td class="px-6 py-5 text-center text-sm text-gray-500 align-top whitespace-nowrap"
+                            th:text="${#temporals.format(notice.createdAt, 'yyyy-MM-dd HH:mm')}">
+                            2026-04-07 10:00
+                        </td>
+
+                        <td class="px-6 py-5 text-center text-sm text-gray-500 align-top whitespace-nowrap"
+                            th:text="${#temporals.format(notice.updatedAt, 'yyyy-MM-dd HH:mm')}">
+                            2026-04-07 10:00
+                        </td>
+
+                        <td class="px-6 py-5 align-top">
+                            <div class="flex items-center justify-center gap-3">
+                                <a th:href="@{/admin/notices/{noticeId}/edit(noticeId=${notice.noticeId})}"
+                                   class="text-sm font-medium text-blue-600 hover:underline">
+                                    수정
+                                </a>
+
+                                <form th:action="@{/admin/notices/{noticeId}/delete(noticeId=${notice.noticeId})}"
+                                      method="post"
+                                      onsubmit="return confirm('공지사항을 삭제하시겠습니까?');">
+                                    <input type="hidden"
+                                           th:name="${_csrf.parameterName}"
+                                           th:value="${_csrf.token}">
+                                    <button type="submit"
+                                            class="text-sm font-medium text-red-600 hover:underline">
+                                        삭제
+                                    </button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="mt-6 flex justify-center" th:if="${noticePage.totalPages > 0}">
+            <div class="flex items-center gap-2 flex-wrap justify-center">
+                <a th:if="${!noticePage.first}"
+                   th:href="@{/admin/notices(page=${currentPage - 1}, size=${size})}"
+                   class="px-3 py-2 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-50">
+                    이전
+                </a>
+
+                <th:block th:each="pageNum : ${#numbers.sequence(1, noticePage.totalPages)}">
+                    <a th:href="@{/admin/notices(page=${pageNum}, size=${size})}"
+                       th:text="${pageNum}"
+                       th:classappend="${pageNum == currentPage} ? ' bg-blue-600 text-white border-blue-600' : ' bg-white text-gray-700 border-gray-300 hover:bg-gray-50'"
+                       class="px-3 py-2 rounded-lg border text-sm font-medium min-w-[40px] text-center">
+                        1
+                    </a>
+                </th:block>
+
+                <a th:if="${!noticePage.last}"
+                   th:href="@{/admin/notices(page=${currentPage + 1}, size=${size})}"
+                   class="px-3 py-2 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-50">
+                    다음
+                </a>
+            </div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/notice-preview.html
+++ b/src/main/resources/templates/fragments/notice-preview.html
@@ -1,0 +1,53 @@
+<th:block th:fragment="noticePreview(notice)">
+    <section class="flex items-center gap-3 px-4 py-3 bg-white border border-gray-200 rounded-xl shadow-sm">
+
+        <!-- 공지 없을 때 -->
+        <div th:if="${notice == null}"
+             class="flex items-center justify-between w-full min-w-0">
+            <div class="flex items-center gap-2 text-sm text-gray-400">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-md bg-gray-100 text-gray-500 text-xs font-medium">
+                    공지
+                </span>
+                <span>등록된 공지사항이 없습니다.</span>
+            </div>
+
+            <a th:href="@{/notices}"
+               class="shrink-0 inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700 transition">
+                <span>목록보기</span>
+                <i class="fi fi-rr-angle-small-right flex items-center leading-none"></i>
+            </a>
+        </div>
+
+        <!-- 공지 있을 때 -->
+        <div th:if="${notice != null}"
+             class="flex items-center justify-between w-full min-w-0 gap-3">
+
+            <div class="flex items-center min-w-0 flex-1 gap-3">
+                <!-- 공지 라벨 -->
+                <span class="shrink-0 inline-flex items-center px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold border border-blue-100">
+                    공지
+                </span>
+
+                <!-- 제목 -->
+                <a th:href="@{/notices/{id}(id=${notice.noticeId})}"
+                   class="min-w-0 flex items-center gap-2 text-sm text-gray-800 hover:text-blue-600 transition">
+
+                    <span class="truncate font-medium"
+                          th:text="${notice.title}">
+                    </span>
+                </a>
+            </div>
+
+            <div class="shrink-0 flex items-center gap-3 text-xs text-gray-400">
+                <span th:text="${#temporals.format(notice.createdAt,'MM.dd')}"></span>
+                <span class="w-px h-3 bg-gray-200"></span>
+
+                <a th:href="@{/notices}"
+                   class="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-700 transition">
+                    <span>목록보기</span>
+                    <i class="fi fi-rr-angle-small-right flex items-center leading-none"></i>
+                </a>
+            </div>
+        </div>
+    </section>
+</th:block>

--- a/src/main/resources/templates/meeting-room/list.html
+++ b/src/main/resources/templates/meeting-room/list.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <link rel='stylesheet' href='https://cdn-uicons.flaticon.com/4.0.0/uicons-regular-rounded/css/uicons-regular-rounded.css'>
     <link rel="stylesheet" th:href="@{/css/meeting-room.css}">
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
@@ -16,8 +17,12 @@
 
 <div th:replace="~{fragments/header :: header}"></div>
 <th:block th:replace="~{fragments/alert-script :: alertScript}"></th:block>
-
 <main class="max-w-7xl mx-auto px-6 py-8">
+
+    <div class="mb-6">
+        <div th:replace="~{fragments/notice-preview :: noticePreview(${notice})}"></div>
+    </div>
+
     <div class="grid grid-cols-12 gap-8">
 
         <aside class="col-span-4">

--- a/src/main/resources/templates/notice/notice-detail.html
+++ b/src/main/resources/templates/notice/notice-detail.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>공지사항 상세 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+
+<body class="bg-gray-50 min-h-screen">
+<div th:replace="~{fragments/header :: header}"></div>
+
+<main class="max-w-4xl mx-auto px-6 py-10">
+
+    <section class="bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
+        <div class="px-8 py-8">
+            <!-- 중요 공지 라벨 (제목 위로 이동) -->
+            <div th:if="${notice.pinned}"
+                 class="mb-3 inline-flex items-center px-3 py-1 rounded-lg bg-blue-50 text-blue-600 text-xs font-semibold">
+                중요 공지
+            </div>
+
+            <!-- 제목 -->
+            <h1 class="text-2xl font-bold text-gray-900 break-words mb-3"
+                th:text="${notice.title}">
+                공지 제목
+            </h1>
+
+            <!-- 메타 -->
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-400">
+                <span class="inline-flex items-center gap-1.5">
+                    <i data-lucide="eye" class="w-4 h-4"></i>
+                    <span>조회수</span>
+                    <span th:text="${notice.viewCount}">0</span>
+                </span>
+
+                <span class="text-gray-300">|</span>
+
+                <span>
+                    작성일
+                    <span th:text="${#temporals.format(notice.createdAt, 'yyyy.MM.dd HH:mm')}"></span>
+                </span>
+
+                <th:block th:if="${notice.updatedAt != null and !notice.updatedAt.equals(notice.createdAt)}">
+                    <span class="text-gray-300">|</span>
+                    <span>
+                        수정일
+                        <span th:text="${#temporals.format(notice.updatedAt, 'yyyy.MM.dd HH:mm')}"></span>
+                    </span>
+                </th:block>
+            </div>
+        </div>
+
+        <!-- 구분선 -->
+        <div class="border-t border-gray-200"></div>
+
+        <!-- 본문 -->
+        <div class="px-8 py-10">
+            <article class="whitespace-pre-line break-words text-[15px] leading-8 text-gray-800"
+                     th:text="${notice.content}">
+                공지사항 본문 내용
+            </article>
+        </div>
+    </section>
+
+    <!-- 목록 버튼 -->
+    <div class="mt-6">
+        <a th:href="@{/notices(page=1, size=10)}"
+           class="inline-flex items-center px-4 py-2 rounded-lg border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
+            목록으로 돌아가기
+        </a>
+    </div>
+
+</main>
+
+<script>
+    lucide.createIcons();
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/notice/notice-list.html
+++ b/src/main/resources/templates/notice/notice-list.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>공지사항 | RoomFlow</title>
+    <link rel="icon" type="image/png" th:href="@{/images/logo_tmp.png}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+
+<body class="bg-gray-50 min-h-screen">
+<div th:replace="~{fragments/header :: header}"></div>
+
+<main class="max-w-5xl mx-auto px-6 py-10">
+
+    <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">공지사항</h1>
+        <p class="text-sm text-gray-500 mt-1">RoomFlow의 새로운 소식과 이용 안내를 확인하세요.</p>
+    </div>
+
+    <section class="bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
+        <div class="grid grid-cols-12 px-6 py-4 bg-gray-50 border-b border-gray-200 text-sm font-medium text-gray-500">
+            <div class="col-span-7">제목</div>
+            <div class="col-span-2 text-center">조회수</div>
+            <div class="col-span-3 text-right">작성일</div>
+        </div>
+
+        <div th:if="${!noticePage.isEmpty()}">
+            <a th:each="notice : ${notices}"
+               th:href="@{/notices/{id}(id=${notice.noticeId})}"
+               class="grid grid-cols-12 items-center px-6 py-4 border-b border-gray-100 last:border-b-0 hover:bg-gray-50 transition">
+
+                <div class="col-span-7 min-w-0 flex items-center gap-2">
+                    <span th:if="${notice.pinned}"
+                          class="shrink-0 inline-flex items-center px-2 py-0.5 rounded-md bg-blue-50 text-blue-600 text-xs font-semibold">
+                        중요
+                    </span>
+
+                    <span class="truncate text-sm font-medium text-gray-800"
+                          th:text="${notice.title}">
+                        공지 제목
+                    </span>
+                </div>
+
+                <div class="col-span-2 text-center text-sm text-gray-500"
+                     th:text="${notice.viewCount}">
+                    0
+                </div>
+
+                <div class="col-span-3 text-right text-sm text-gray-400"
+                     th:text="${#temporals.format(notice.createdAt, 'yyyy.MM.dd')}">
+                    2026.04.08
+                </div>
+            </a>
+        </div>
+
+        <div th:if="${noticePage.isEmpty()}"
+             class="py-16 text-center text-sm text-gray-400">
+            등록된 공지사항이 없습니다.
+        </div>
+    </section>
+
+    <!-- pagination -->
+    <nav th:if="${noticePage.totalPages > 1}"
+         class="mt-8 flex items-center justify-center gap-2">
+
+        <!-- 이전 -->
+        <a th:if="${currentPage > 1}"
+           th:href="@{/notices(page=${currentPage - 1}, size=${size})}"
+           class="inline-flex items-center justify-center min-w-[44px] h-10 px-3 rounded-lg border border-gray-300 bg-white text-sm text-gray-600 hover:bg-gray-50 transition">
+            이전
+        </a>
+        <span th:unless="${currentPage > 1}"
+              class="inline-flex items-center justify-center min-w-[44px] h-10 px-3 rounded-lg border border-gray-200 bg-gray-100 text-sm text-gray-300 cursor-default">
+            이전
+        </span>
+
+        <!-- 페이지 번호 -->
+        <th:block th:each="pageNum : ${#numbers.sequence(1, noticePage.totalPages)}">
+            <a th:if="${pageNum != currentPage}"
+               th:href="@{/notices(page=${pageNum}, size=${size})}"
+               class="inline-flex items-center justify-center w-10 h-10 rounded-lg border border-gray-300 bg-white text-sm text-gray-600 hover:bg-gray-50 transition"
+               th:text="${pageNum}">
+                1
+            </a>
+
+            <span th:if="${pageNum == currentPage}"
+                  class="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-blue-600 text-white text-sm font-semibold"
+                  th:text="${pageNum}">
+                1
+            </span>
+        </th:block>
+
+        <!-- 다음 -->
+        <a th:if="${currentPage < noticePage.totalPages}"
+           th:href="@{/notices(page=${currentPage + 1}, size=${size})}"
+           class="inline-flex items-center justify-center min-w-[44px] h-10 px-3 rounded-lg border border-gray-300 bg-white text-sm text-gray-600 hover:bg-gray-50 transition">
+            다음
+        </a>
+        <span th:unless="${currentPage < noticePage.totalPages}"
+              class="inline-flex items-center justify-center min-w-[44px] h-10 px-3 rounded-lg border border-gray-200 bg-gray-100 text-sm text-gray-300 cursor-default">
+            다음
+        </span>
+    </nav>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## 📌 Related Issue
#95 closed
## 🚀 Description
1. 관리자
- 공지사항 생성, 수정, 삭제 가능
- 공지사항 목록, 세부 정보조회 가능

2. 사용자
- 메인 화면에서 가장 상단의 공지사항 조회 가능 -> 목록으로 이동 가능
- 공지사항 목록 조회 가능, 세부 정보 확인 가능

## 📢 Notes
